### PR TITLE
Don't convert quotes when Vim is not inserting

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
             {
                 "key": "shift+[",
                 "command": "backticks.convertQuotes",
-                "when": "editorTextFocus"
+                "when": "editorTextFocus && vim.mode != 'Normal' && vim.mode != 'Visual' && vim.mode != 'VisualBlock' && vim.mode != 'VisualLine' && vim.mode != 'SearchInProgressMode' && vim.mode != 'CommandlineInProgress' && vim.mode != 'EasyMotionMode' && vim.mode != 'EasyMotionInputMode' && vim.mode != 'SurroundInputMode'"
             }
         ]
     },


### PR DESCRIPTION
The Vim plugin uses the { key as a motion key, except in insert mode. This change makes this extension only convert quotes when Vim is not in an insert mode. Since the variable `vim.mode` is not defined when the Vim extension is not installed, a very long list of modes that should suppress this extension is used. That way quote replacing behavior works both with and without the Vim extension installed.

This uses an exhaustive negative list instead of the much shorter positive list because the positive list would break when `vim.mode` does not exist, such as when the Vim plugin is not installed. I couldn't figure out a way to make this check dependent on the existence of the Vim plugin or `vim.mode`.